### PR TITLE
Handle missing cards when building chain selection list

### DIFF
--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -1932,6 +1932,15 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			ss = BufferIO::Read<uint8_t>(pbuf);
 			desc = BufferIO::Read<int32_t>(pbuf);
 			pcard = mainGame->dField.GetCard(c, l, s, ss);
+			if(!pcard) {
+				pcard = new ClientCard();
+				mainGame->dField.limbo_temp.push_back(pcard);
+				panelmode = true;
+			}
+			if(!pcard)
+				continue;
+			if(code != 0 && pcard->code != code)
+				pcard->SetCode(code);
 			mainGame->dField.activatable_cards.push_back(pcard);
 			mainGame->dField.activatable_descs.push_back(std::make_pair(desc, flag));
 			pcard->is_selected = false;


### PR DESCRIPTION
## Summary
- ensure chain selection builds temporary client cards when field lookup fails so the UI keeps working and avoids null dereferences

## Testing
- not run (manual GUI testing required and not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6d96ebb288324929f987f0dcd93b6