### PR TITLE
Prevent chain selection crash on missing cards

### DIFF
--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -91,6 +91,9 @@ void ClientField::Clear() {
 	for(auto cit = limbo_temp.begin(); cit != limbo_temp.end(); ++cit)
 			delete *cit;
 	limbo_temp.clear();
+	for(auto cit = chain_temp.begin(); cit != chain_temp.end(); ++cit)
+			delete *cit;
+	chain_temp.clear();
 	for(auto sit = overlay_cards.begin(); sit != overlay_cards.end(); ++sit)
 		delete *sit;
 	overlay_cards.clear();
@@ -410,21 +413,27 @@ void ClientField::ClearSelect() {
 	}
 }
 void ClientField::ClearChainSelect() {
-	for(auto cit = activatable_cards.begin(); cit != activatable_cards.end(); ++cit) {
-		(*cit)->cmdFlag = 0;
-		(*cit)->chain_code = 0;
-		(*cit)->is_selectable = false;
-		(*cit)->is_selected = false;
-	}
-	for(int i = 0; i < 2; ++i) {
-		deck_act[i] = false;
-		extra_act[i] = false;
-		grave_act[i] = false;
-		remove_act[i] = false;
-		pzone_act[i] = false;
-	}
-	conti_cards.clear();
-	conti_act = false;
+        for(auto cit = activatable_cards.begin(); cit != activatable_cards.end(); ++cit) {
+                ClientCard* pcard = *cit;
+                if(!pcard)
+                        continue;
+                pcard->cmdFlag = 0;
+                pcard->chain_code = 0;
+                pcard->is_selectable = false;
+                pcard->is_selected = false;
+        }
+        for(int i = 0; i < 2; ++i) {
+                deck_act[i] = false;
+                extra_act[i] = false;
+                grave_act[i] = false;
+                remove_act[i] = false;
+                pzone_act[i] = false;
+        }
+        conti_cards.clear();
+        conti_act = false;
+	for(auto cit = chain_temp.begin(); cit != chain_temp.end(); ++cit)
+                delete *cit;
+	chain_temp.clear();
 }
 // needs to be synchronized with EGET_SCROLL_BAR_CHANGED
 void ClientField::ShowSelectCard(bool buttonok, bool chain) {

--- a/gframe/client_field.h
+++ b/gframe/client_field.h
@@ -32,7 +32,8 @@ public:
 	std::vector<ClientCard*> grave[2];
 	std::vector<ClientCard*> remove[2];
 	std::vector<ClientCard*> extra[2];
-	std::vector<ClientCard*> limbo_temp;
+        std::vector<ClientCard*> limbo_temp;
+        std::vector<ClientCard*> chain_temp;
 	std::set<ClientCard*> overlay_cards;
 
 	std::vector<ClientCard*> summonable_cards;

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -1923,36 +1923,57 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 			s = BufferIO::Read<uint8_t>(pbuf);
 			ss = BufferIO::Read<uint8_t>(pbuf);
 			desc = BufferIO::Read<int32_t>(pbuf);
-			pcard = mainGame->dField.GetCard(c, l, s, ss);
-			mainGame->dField.activatable_cards.push_back(pcard);
-			mainGame->dField.activatable_descs.push_back(std::make_pair(desc, flag));
-			pcard->is_selected = false;
-			if(forced) {
-				mainGame->dField.chain_forced = true;
-			}
-			if(flag & EDESC_OPERATION) {
-				pcard->chain_code = code;
-				mainGame->dField.conti_cards.push_back(pcard);
-				mainGame->dField.conti_act = true;
-				conti_exist = true;
-			} else {
-				pcard->is_selectable = true;
-				if(flag & EDESC_RESET)
-					pcard->cmdFlag |= COMMAND_RESET;
-				else
-					pcard->cmdFlag |= COMMAND_ACTIVATE;
-				if(pcard->location == LOCATION_DECK) {
-					pcard->SetCode(code);
-					mainGame->dField.deck_act[c] = true;
-				} else if(l == LOCATION_GRAVE)
-					mainGame->dField.grave_act[c] = true;
-				else if(l == LOCATION_REMOVED)
-					mainGame->dField.remove_act[c] = true;
-				else if(l == LOCATION_EXTRA)
-					mainGame->dField.extra_act[c] = true;
-				else if(l == LOCATION_OVERLAY)
-					panelmode = true;
-			}
+                       pcard = mainGame->dField.GetCard(c, l, s, ss);
+                       bool is_placeholder = false;
+                       if(!pcard) {
+                               pcard = new ClientCard();
+                               is_placeholder = true;
+                               pcard->controler = c;
+                               pcard->location = l;
+                               pcard->sequence = s;
+                               pcard->position = (l & LOCATION_OVERLAY) ? 0 : (unsigned char)ss;
+                               if(code)
+                                       pcard->SetCode(code);
+                               else
+                                       pcard->code = 0;
+                               mainGame->dField.chain_temp.push_back(pcard);
+                               panelmode = true;
+                       } else if(code != 0 && pcard->code != code) {
+                               pcard->SetCode(code);
+                       }
+                       mainGame->dField.activatable_cards.push_back(pcard);
+                       mainGame->dField.activatable_descs.push_back(std::make_pair(desc, flag));
+                       pcard->is_selected = false;
+                       if(forced) {
+                               mainGame->dField.chain_forced = true;
+                       }
+                       if(flag & EDESC_OPERATION) {
+                               if(!is_placeholder) {
+                                       pcard->chain_code = code;
+                                       mainGame->dField.conti_cards.push_back(pcard);
+                                       mainGame->dField.conti_act = true;
+                                       conti_exist = true;
+                               }
+                       } else {
+                               pcard->is_selectable = true;
+                               if(!is_placeholder) {
+                                       if(flag & EDESC_RESET)
+                                               pcard->cmdFlag |= COMMAND_RESET;
+                                       else
+                                               pcard->cmdFlag |= COMMAND_ACTIVATE;
+                                       if(pcard->location == LOCATION_DECK) {
+                                               pcard->SetCode(code);
+                                               mainGame->dField.deck_act[c] = true;
+                                       } else if(l == LOCATION_GRAVE)
+                                               mainGame->dField.grave_act[c] = true;
+                                       else if(l == LOCATION_REMOVED)
+                                               mainGame->dField.remove_act[c] = true;
+                                       else if(l == LOCATION_EXTRA)
+                                               mainGame->dField.extra_act[c] = true;
+                                       else if(l == LOCATION_OVERLAY)
+                                               panelmode = true;
+                               }
+                       }
 		}
 		if(!select_trigger && !mainGame->dField.chain_forced && (mainGame->ignore_chain || ((count == 0 || specount == 0) && !mainGame->always_chain)) && (count == 0 || !mainGame->chain_when_avail)) {
 			SetResponseI(-1);


### PR DESCRIPTION
## Summary
- guard chain selection against missing field cards by creating temporary client cards, keeping activatable indices aligned, and falling back to the panel UI when needed
- track placeholder chain cards so ClearChainSelect() can skip nulls and free any temporary allocations

## Testing
- not run (manual reproduction of the forced-chain scenario requires a full server/client environment)

------
https://chatgpt.com/codex/tasks/task_e_68d6d64ecac08324b249831d1dcf411b