### PR TITLE
Handle composite location flags and guard missing chain cards

### DIFF
--- a/gframe/client_field.cpp
+++ b/gframe/client_field.cpp
@@ -153,15 +153,34 @@ void ClientField::ResetSequence(std::vector<ClientCard*>& list, bool reset_heigh
 	}
 }
 ClientCard* ClientField::GetCard(int controler, int location, int sequence, int sub_seq) {
-	std::vector<ClientCard*>* lst = 0;
-	bool is_xyz = (location & LOCATION_OVERLAY) != 0;
-	location &= 0x7f;
-	switch(location) {
-	case LOCATION_DECK:
-		lst = &deck[controler];
-		break;
-	case LOCATION_HAND:
-		lst = &hand[controler];
+        std::vector<ClientCard*>* lst = 0;
+        bool is_xyz = (location & LOCATION_OVERLAY) != 0;
+        int normalized_location = location & ~LOCATION_OVERLAY;
+        if(normalized_location & (LOCATION_FZONE | LOCATION_PZONE))
+                normalized_location |= LOCATION_SZONE;
+        const int kBaseLocationMask = LOCATION_DECK | LOCATION_HAND | LOCATION_MZONE | LOCATION_SZONE
+                | LOCATION_GRAVE | LOCATION_REMOVED | LOCATION_EXTRA;
+        auto lowest_set_bit = [](int value) -> int {
+                for(unsigned int bit = 1u; bit != 0u; bit <<= 1u) {
+                        if(value & static_cast<int>(bit))
+                                return static_cast<int>(bit);
+                }
+                return 0;
+        };
+        int base_location = normalized_location & kBaseLocationMask;
+        if(base_location == 0)
+                base_location = lowest_set_bit(normalized_location);
+        if(base_location & (base_location - 1))
+                base_location = lowest_set_bit(base_location);
+        if(base_location == 0)
+                return 0;
+        location = base_location;
+        switch(location) {
+        case LOCATION_DECK:
+                lst = &deck[controler];
+                break;
+        case LOCATION_HAND:
+                lst = &hand[controler];
 		break;
 	case LOCATION_MZONE:
 		lst = &mzone[controler];

--- a/gframe/duelclient.cpp
+++ b/gframe/duelclient.cpp
@@ -13,6 +13,9 @@
 #endif
 #include <thread>
 #include <algorithm>
+#include <string>
+#include <sstream>
+#include <iomanip>
 
 namespace ygo {
 
@@ -1913,26 +1916,42 @@ bool DuelClient::ClientAnalyze(unsigned char* msg, int len) {
 		mainGame->dField.activatable_cards.clear();
 		mainGame->dField.activatable_descs.clear();
 		mainGame->dField.conti_cards.clear();
-		for (int i = 0; i < count; ++i) {
-			int flag = BufferIO::Read<uint8_t>(pbuf);
-			int forced = BufferIO::Read<uint8_t>(pbuf);
-			flag |= forced << 8;
-			code = BufferIO::Read<int32_t>(pbuf);
-			c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
-			l = BufferIO::Read<uint8_t>(pbuf);
-			s = BufferIO::Read<uint8_t>(pbuf);
-			ss = BufferIO::Read<uint8_t>(pbuf);
-			desc = BufferIO::Read<int32_t>(pbuf);
-			pcard = mainGame->dField.GetCard(c, l, s, ss);
-			mainGame->dField.activatable_cards.push_back(pcard);
-			mainGame->dField.activatable_descs.push_back(std::make_pair(desc, flag));
-			pcard->is_selected = false;
-			if(forced) {
-				mainGame->dField.chain_forced = true;
-			}
-			if(flag & EDESC_OPERATION) {
-				pcard->chain_code = code;
-				mainGame->dField.conti_cards.push_back(pcard);
+                for (int i = 0; i < count; ++i) {
+                        int flag = BufferIO::Read<uint8_t>(pbuf);
+                        int forced = BufferIO::Read<uint8_t>(pbuf);
+                        bool is_forced_entry = forced != 0;
+                        flag |= forced << 8;
+                        code = BufferIO::Read<int32_t>(pbuf);
+                        c = mainGame->LocalPlayer(BufferIO::Read<uint8_t>(pbuf));
+                        l = BufferIO::Read<uint8_t>(pbuf);
+                        s = BufferIO::Read<uint8_t>(pbuf);
+                        ss = BufferIO::Read<uint8_t>(pbuf);
+                        desc = BufferIO::Read<int32_t>(pbuf);
+                        pcard = mainGame->dField.GetCard(c, l, s, ss);
+                        if(!pcard) {
+                                // Guard against protocol entries that reference unresolved cards; log for diagnostics.
+                                std::ostringstream oss;
+                                oss << "[chain] Skipped entry missing card (controller=" << c
+                                        << ", location=" << std::showbase << std::hex << l
+                                        << std::dec << ", sequence=" << s
+                                        << ", sub_seq=" << ss
+                                        << ", flag=" << std::showbase << std::hex << flag
+                                        << std::dec << ", desc=" << desc << ')';
+                                const std::string debug_message = oss.str();
+                                mainGame->AddDebugMsg(debug_message.c_str());
+                                if(is_forced_entry)
+                                        mainGame->dField.chain_forced = true;
+                                continue;
+                        }
+                        mainGame->dField.activatable_cards.push_back(pcard);
+                        mainGame->dField.activatable_descs.emplace_back(desc, flag);
+                        pcard->is_selected = false;
+                        if(is_forced_entry) {
+                                mainGame->dField.chain_forced = true;
+                        }
+                        if(flag & EDESC_OPERATION) {
+                                pcard->chain_code = code;
+                                mainGame->dField.conti_cards.push_back(pcard);
 				mainGame->dField.conti_act = true;
 				conti_exist = true;
 			} else {


### PR DESCRIPTION
## Summary
- normalize composite location flags in `ClientField::GetCard` so the correct zone is resolved even when multiple bits are set
- guard MSG_SELECT_CHAIN entries without a resolved card by logging and skipping them instead of dereferencing null pointers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6eb2eac788324a30654cf7253717a