### PR TITLE
Expand Chinese engine references

### DIFF
--- a/dev/docs/cpp_modules_overview_zh.md
+++ b/dev/docs/cpp_modules_overview_zh.md
@@ -1,0 +1,92 @@
+# C++ 模块全景文档（经代码验证）
+
+## 1. 项目结构与依赖
+本项目的 C++ 代码主要分布在 `ocgcore` 与 `gframe` 两大目录：
+
+- **`ocgcore`**：封装对外 C 接口、决斗容器、规则执行状态机、卡牌/效果数据模型，以及 Lua 脚本绑定，是服务器与客户端共享的对局引擎。【F:ocgcore/ocgapi.h†L39-L83】【F:ocgcore/duel.h†L29-L76】【F:ocgcore/field.h†L36-L200】【F:ocgcore/interpreter.h†L27-L88】
+- **`gframe`**：构建客户端运行时，涵盖窗口/渲染初始化、对局数据结构、网络通信、音频及资源加载模块，是玩家与核心交互的宿主环境。【F:gframe/game.cpp†L34-L138】【F:gframe/client_field.h†L26-L164】【F:gframe/network.h†L4-L195】【F:gframe/sound_manager.h†L15-L105】
+
+运行时依赖包括 Irrlicht 图形引擎（渲染/UI）、libevent（网络）、SQLite（卡片数据库）以及可选的 miniaudio/irrKlang 音频后端，这些库均在各自模块的头文件与初始化逻辑中显式引用。【F:gframe/game.h†L4-L126】【F:gframe/network.h†L4-L195】【F:gframe/data_manager.h†L4-L139】【F:gframe/sound_manager.h†L6-L56】
+
+## 2. 决斗核心（`ocgcore`）
+### 2.1 模块总览
+核心文件之间的协作关系如下：
+
+- `duel.h/cpp` 管理整局对决的生命周期、消息缓冲与对象池。【F:ocgcore/duel.h†L29-L76】
+- `field.h/cpp`、`processor.cpp`、`operations.cpp` 与 `playerop.cpp` 共同组成状态机：`field::process` 轮询 `processor_unit` 队列，根据类型执行流程或等待响应，具体操作（召唤、破坏、移动等）由 `operations.cpp` 推入队列，而玩家交互流程在 `playerop.cpp` 中编码。【F:ocgcore/field.h†L144-L200】【F:ocgcore/processor.cpp†L17-L185】【F:ocgcore/operations.cpp†L151-L247】【F:ocgcore/playerop.cpp†L15-L112】
+- `card.h`、`group.h`、`effect.h` 定义了运行时对象及其关系；`metadata.*`、`buffer.h` 等提供辅助结构。【F:ocgcore/card.h†L37-L200】【F:ocgcore/group.h†L20-L44】【F:ocgcore/effect.h†L29-L130】
+- `interpreter.h/cpp` 与 `scriptlib.*` 管理 Lua 虚拟机及脚本 API，使得卡片效果可由脚本扩展。【F:ocgcore/interpreter.h†L27-L88】【F:ocgcore/scriptlib.h†L18-L200】【F:ocgcore/libduel.cpp†L20-L187】
+
+### 2.2 C 接口与宿主集成
+`ocgapi.h` 暴露的 `extern "C"` 函数允许任何宿主加载规则引擎：
+
+- **资源回调**：`set_script_reader`、`set_card_reader`、`set_message_handler` 注册宿主回调；辅助函数 `read_script`/`read_card`/`handle_message` 统一访问路径。【F:ocgcore/ocgapi.h†L39-L49】
+- **决斗生命周期**：`create_duel`/`create_duel_v2` 创建实例，`start_duel`/`end_duel` 管控启动与清理，`set_player_info` 与一组补给函数初始化对局资源值。【F:ocgcore/ocgapi.h†L51-L61】
+- **消息驱动**：宿主循环调用 `process` 推进状态，通过 `get_message`/`get_log_message` 读取输出，并用 `set_responsei`/`set_responseb` 注入玩家响应；`preload_script` 支持脚本预热。【F:ocgcore/ocgapi.h†L62-L74】
+- **状态查询与扩展**：`new_card`、`query_card`、`query_field_*` 等读写场地；Koishi 特有的注册表 API 提供跨决斗共享数据的键值对。【F:ocgcore/ocgapi.h†L65-L83】
+
+典型宿主流程会先注册资源回调，再创建对局并在主循环中交替调用 `process` 与 `get_message` 直至 `PROCESSOR_END` 标志出现，同时根据玩家输入调用响应接口继续推进。
+
+### 2.3 决斗容器（`duel`）
+`duel` 对象统筹所有运行时资源：
+
+- **成员组成**：持有 Lua 解释器、`field` 场地、梅森旋转随机数、全局元数据及用于垃圾回收的 `std::unordered_set` 容器。【F:ocgcore/duel.h†L29-L44】
+- **消息缓冲**：`write_buffer*`/`read_buffer`/`buffer_size` 负责序列化协议字节流，宿主通过 `get_message` 即读取该缓冲的内容。【F:ocgcore/duel.h†L52-L69】
+- **对象工厂与生命周期**：`new_card`/`new_group`/`new_effect` 及对应删除函数集中管理运行对象，确保 C++ 与 Lua 引用同步；`registry` 则承载可持久化的引擎配置。【F:ocgcore/duel.h†L55-L76】
+
+### 2.4 场地、事件与流程调度
+`field` 类及其内嵌结构描述对局状态，并通过 `processor` 管理流程：
+
+- **事件建模**：`tevent`、`chain`、`optarget` 记录触发源、目标集合、连锁顺序与附加参数，为效果解析提供上下文。【F:ocgcore/field.h†L36-L79】
+- **玩家与场地信息**：`player_info` 保存各区域卡组列表、补给值、禁用区域等；`field_effect` 维护永续/触发效果容器与授予关系；`field_info` 跟踪回合、阶段与唯一标识。【F:ocgcore/field.h†L81-L138】
+- **处理队列**：`processor` 内含 `processor_unit` 链表与多种候选卡集合（可召唤/可攻击等），驱动规则解析和玩家选择。【F:ocgcore/field.h†L144-L200】
+- **执行循环**：`field::process` 按 `processor_unit::type` 分发到调整、回合推进、玩家选择、位置选择等分支，若需要玩家输入则返回 `PROCESSOR_WAITING` 并保留状态。【F:ocgcore/processor.cpp†L35-L185】
+- **动作排队**：诸如 `special_summon`、`destroy`、`release` 等高层操作在 `operations.cpp` 中设置卡片状态、填充原因信息，并调用 `add_process` 将 `PROCESSOR_*` 单元压入队列，确保动画与脚本按统一机制推进。【F:ocgcore/operations.cpp†L151-L247】
+- **玩家输入协议**：`playerop.cpp` 的 `select_battle_command`、`select_idle_command` 等函数把候选选项编码进消息缓冲，并验证宿主返回值合法性，保证客户端不会提交越界索引。【F:ocgcore/playerop.cpp†L15-L112】
+
+### 2.5 运行对象模型
+- **卡牌（`card`）**：`card_state` 保存当前/历史属性，`query_cache` 避免重复计算，`material_info` 记录召唤素材限制。类本体包含所有运行时标记（控制者、唯一 ID、装备关系、计数器等）以及效果容器，支撑复杂的召唤与效果判定。【F:ocgcore/card.h†L37-L200】
+- **卡组集合（`group`）**：封装一组卡牌指针并携带引用计数、元数据和读写标记，常用于传递查询结果或脚本层的选择集合。【F:ocgcore/group.h†L20-L44】
+- **效果（`effect`）**：记录触发范围、计数限制、重置规则、提示信息等元数据，并提供 `is_activateable`、`check_count_limit`、`get_value` 等实用方法，用于判断脚本条件和读取返回值。【F:ocgcore/effect.h†L29-L130】
+
+### 2.6 Lua 脚本环境
+- **解释器**：`interpreter` 负责 Lua 状态创建、协程管理、参数入栈及函数调用，支持注册/注销 card、group、effect 实例并在 Lua 侧维护弱引用，防止悬挂指针。【F:ocgcore/interpreter.h†L27-L88】
+- **脚本库**：`scriptlib` 暴露大量以 `card_*`、`effect_*`、`duel_*` 开头的 API，涵盖属性查询、效果注册、数据库读取、随机数和注册表访问，为脚本提供与引擎交互的唯一入口。【F:ocgcore/scriptlib.h†L18-L200】
+- **宿主辅助实现**：`libduel.cpp` 中的函数（如 `duel_query_database`、`duel_read_card`）实现了脚本 API，包含输入校验与只读 SQLite 查询，确保脚本访问安全可控。【F:ocgcore/libduel.cpp†L20-L187】
+
+## 3. 客户端运行框架（`gframe`）
+### 3.1 Game 入口与配置
+`Game` 类是客户端的主循环入口：
+
+- `Config` 结构罗列渲染、字体、网络、音频等设置，`DuelInfo` 记录 LP、补给、阶段、倒计时与 UI 文本缓冲，`BotInfo`/`FadingUnit` 等则服务于 AI 对战与界面动画。【F:gframe/game.h†L57-L193】
+- `Game::Initialize` 负责创建 Irrlicht 设备、加载皮肤、初始化 `DeckManager`、`ImageManager`、`DataManager` 与字符串/服务器配置，同时尝试加载额外卡片数据库并建立 GUI 环境。【F:gframe/game.cpp†L34-L137】
+
+### 3.2 数据载入与卡组管理
+- **DataManager**：读取 SQLite 卡片库、字符串、服务器列表，并提供编号/文本检索、格式化工具以及静态的 `CardReader`/`ScriptReaderEx` 以供 OCGCore 回调直接使用。【F:gframe/data_manager.h†L22-L139】
+- **DeckManager**：在 `current_deck` 内维护主、额外、备牌列表，支持 LF 禁限表加载、卡组导入导出及生成网络协议所需的数组形式，是 UI、网络与核心之间的数据桥梁。【F:gframe/deck_manager.h†L42-L155】
+
+### 3.3 客户端场景与交互
+`ClientField` 将对局现场映射为客户端对象：追踪各区域卡牌向量、可操作列表、当前连锁、提示与选项，并实现事件响应（鼠标命中、菜单、选中集合），供 UI 层渲染与交互逻辑调用。【F:gframe/client_field.h†L26-L164】
+
+### 3.4 网络通信
+- `network.h` 定义客户端/服务器协议的数据结构，并使用 `static_assert` 确保与网络字节布局兼容；同时提供缓冲区大小常量供序列化使用。【F:gframe/network.h†L16-L195】
+- `DuelClient` 基于 libevent 管理网络会话：维护连接状态、发送缓冲、远程房间刷新线程，并提供 `SendPacketToServer`、`SetResponseI/B` 等静态方法与核心消息交互。【F:gframe/duelclient.h†L53-L157】
+- `NetServer` 在服务器模式下监听连接、转发消息，并复用协议结构体封装发送逻辑（含重发缓冲），用于本地或远程对战服务器。【F:gframe/netserver.h†L10-L69】
+
+### 3.5 音频系统
+`SoundManager` 统一 BGM/音效播放，内部根据编译选项选择 miniaudio 或 irrKlang，并暴露 `PlayBGM`、`PlaySoundEffect`、`SetSoundVolume` 等接口供 UI 触发场景音频。【F:gframe/sound_manager.h†L15-L105】
+
+### 3.6 与核心引擎的交互路径
+客户端在多处将资源读取与消息处理对接至 OCGCore：
+
+- 回放与单人模式启动时，调用 `set_script_reader(DataManager::ScriptReaderEx)`、`set_card_reader(DataManager::CardReader)` 和 `set_message_handler`，随后创建 `pduel`，设置玩家信息并预加载脚本，从而驱动核心引擎运行。【F:gframe/replay_mode.cpp†L23-L195】
+- 游戏运行期通过 `process`/`get_message` 循环驱动 UI，并用 `set_responseb` 回填回放指令，逻辑与实时对战保持一致。【F:gframe/replay_mode.cpp†L80-L118】
+
+## 4. 集成实践建议
+1. **初始化资源**：客户端应在启动时加载卡片数据库与字符串，并注册 `DataManager` 的脚本/卡片读取回调，确保核心引擎访问到统一的资源缓存。【F:gframe/game.cpp†L88-L120】【F:gframe/data_manager.h†L116-L125】
+2. **创建决斗**：根据对战参数调用 `create_duel`/`create_duel_v2`，设置玩家 LP、起始手牌、补给等，再执行 `start_duel` 并进入 `process` 循环。【F:gframe/replay_mode.cpp†L157-L195】【F:ocgcore/ocgapi.h†L51-L63】
+3. **消息循环**：每帧读取 `process` 返回的缓冲长度，使用 `get_message` 解包后驱动 UI/音频，并在玩家操作后调用 `set_response*` 或网络发送函数同步状态。【F:gframe/replay_mode.cpp†L80-L118】【F:ocgcore/ocgapi.h†L62-L74】
+4. **扩展脚本**：新增效果时在 Lua 中调用 `scriptlib` 提供的 `card_*`/`duel_*` API，可结合 `preload_script` 与 `DataManager::LoadExtraScripts` 实现热加载及补丁管理。【F:ocgcore/scriptlib.h†L18-L200】【F:ocgcore/libduel.cpp†L92-L195】【F:gframe/replay_mode.cpp†L190-L195】
+5. **网络/服务端部署**：使用 `DuelClient`/`NetServer` 的封装确保与协议结构体一致，通过 libevent 事件循环读写消息；服务器侧可重发上次写入的缓冲保证可靠性。【F:gframe/duelclient.h†L65-L157】【F:gframe/netserver.h†L21-L69】
+
+以上内容基于源码逐项验证，旨在帮助开发者快速定位需要扩展或集成的组件，并掌握核心引擎与宿主框架之间的调用约定。

--- a/dev/docs/engine/gframe_engine_reference_zh.md
+++ b/dev/docs/engine/gframe_engine_reference_zh.md
@@ -1,0 +1,66 @@
+# gframe 客户端框架详解
+
+本文档聚焦 `gframe/` 目录下的 C++ 模块，进一步拆解 UI 客户端在初始化流程、资源管理、网络通信、场面渲染与多模式支持中的职责，便于 UI/前端与工具开发者深入理解引擎联动细节。
+
+## 1. 应用入口与生命周期
+
+`Game::Initialize()` 是客户端启动入口：创建 Irrlicht 设备、解析配置与皮肤、载入限制表/卡片数据库/字符串/服务器列表，并初始化图像、字体、音频、GUI 环境等依赖，为后续场景构建打好基础。【F:gframe/game.cpp†L33-L239】
+
+界面控件（主菜单、联机房间、建房面板、图像与提示窗口等）也在初始化阶段构建并根据配置调整尺寸与皮肤，随后把事件接收器绑定到 `menuHandler`。【F:gframe/game.cpp†L240-L1147】
+
+`Game::MainLoop()` 则负责主渲染循环：设置摄像机与投影视图，检测窗口尺寸变化，绘制战场/菜单/牌组编辑界面，调度 `SoundManager` 播放对应场景 BGM，并在每帧处理 Steam 状态、关闭信号与 FPS 统计等杂务。【F:gframe/game.cpp†L1157-L1279】
+
+## 2. 数据与资源管理
+
+`DataManager` 抽象卡片数据、字符串、服务器列表与脚本加载，提供卡片查询、文本格式化、系列检索、脚本回调等接口，外部依赖通过它获取卡片信息并在需要时加载额外脚本文件。【F:gframe/data_manager.h†L18-L139】
+
+`DeckManager` 维护当前牌组、限制表集合与 `.ydk` 读写逻辑，提供从文件/流读取、保存、分类管理、合法性校验与卡片统计等功能，是牌组编辑器与房间校验的底层支撑。【F:gframe/deck_manager.h†L42-L155】
+
+图像资源通过 `ImageManager` 与 `Game::Initialize()` 中的 `imageManager.Initial()` 注入设备并加载，音频资源则由 `SoundManager` 初始化后统一管理，分别负责贴图与音效/BGM 的生命周期。【F:gframe/game.cpp†L125-L239】【F:gframe/sound_manager.h†L15-L106】
+
+## 3. 界面与输入分发
+
+初始化阶段创建的 GUI 控件在 `menuHandler` 与 `ClientField` 的事件系统下运作：
+
+- `ClientField::OnEvent` 根据按钮/列表/鼠标事件分发到对战操作（如猜拳、先后手、投降、连锁设置、录像控制等），并通过 `DuelClient` 或 `ReplayMode` 发送网络/本地指令。【F:gframe/event_handler.cpp†L16-L198】
+- `ClientField` 自身持有大量列表（手牌、怪区、陷区等）与交互状态，用于在 UI 侧维护客户端牌面、选择面板与链信息，并暴露方法刷新动画、选择状态与响应封装。【F:gframe/client_field.h†L26-L164】【F:gframe/client_field.cpp†L12-L144】
+
+窗口级事件在 `Game` 中转换：初始化阶段设置 `device->setEventReceiver(&menuHandler)`，在进入对战后切换到 `ClientField` 处理实时操作，实现菜单与对战 UI 的分离。【F:gframe/game.cpp†L1126-L1156】
+
+## 4. 网络通信栈
+
+`network.h` 定义了客户端与服务器之间的结构体、缓冲区限制与常量，包括主机信息、玩家/房间封包、聊天长度等，保证所有网络消息具有确定的内存布局，可直接写入 libevent 缓冲区。【F:gframe/network.h†L16-L195】
+
+`DuelClient` 封装所有客户端网络行为：
+
+- `StartClient` 创建 libevent `bufferevent`、建立连接、开启线程，并根据是否建房附加超时处理，同时重置随机数与缓存状态。【F:gframe/duelclient.cpp†L435-L465】
+- `ClientRead` 从缓冲区分段读取消息，调用 `HandleSTOCPacketLan` 分析服务器指令；`ClientEvent` 处理连接成功或异常，更新 UI 按钮状态并分发提示。【F:gframe/duelclient.cpp†L497-L520】【F:gframe/duelclient.cpp†L515-L707】
+- `HandleSTOCPacketLan` 根据协议类型分派：对战消息转交 `ClientAnalyze`、错误提示根据错误码弹窗/复用 UI 控件、房间列表刷新、录像交互等都在此集中处理。【F:gframe/duelclient.cpp†L666-L855】
+
+内置 `NetServer` 可启动房主模式或局域网广播，封装监听、accept、读写与广播逻辑，并提供向玩家发送数据、重发缓存、断线清理等工具，方便客户端在本地直接承载服务器功能。【F:gframe/netserver.h†L10-L69】
+
+## 5. 客户端场面模型
+
+`ClientField` 维持前端需要渲染的全部卡片实体（牌组、手牌、场区、墓地、除外、额外区等）与交互列表（可召唤、可发动、可攻击等），并提供获取/添加/移动卡片、刷新计数、构建选择面板等方法，确保 UI 与 ocgcore 消息保持同步。【F:gframe/client_field.h†L26-L164】
+
+实现层在 `client_field.cpp` 中完成资源回收、初始分布、序列重排、卡片动画与选项弹窗等具体逻辑，在接收到 `DuelClient` 转来的网络消息后更新界面状态，驱动 3D 卡牌与 GUI 控件的联动。【F:gframe/client_field.cpp†L12-L198】
+
+## 6. 单机、录像与辅助模式
+
+`SingleMode` 为单人脚本模式封装独立的 `pduel`、消息分析、响应设置与区域刷新流程，提供专门的线程入口与消息处理函数，使单机剧情无需外部服务器即可运行。【F:gframe/single_mode.h†L10-L37】
+
+`Replay` 负责 `.yrp`/`.yrpX` 录像的头部扩展、数据写入与读取，支持压缩标志、种子序列、牌组列表、响应流等结构化信息，并提供保存、重命名、删除等工具函数，配合 UI 实现录像回放与存档管理。【F:gframe/replay.h†L12-L121】
+
+录像/单机相关按钮事件在 `ClientField::OnEvent` 中集中处理，通过 `ReplayMode` 或 `SingleMode` 的接口触发暂停、单步、重放、退出等行为，实现多模式共享 UI。【F:gframe/event_handler.cpp†L52-L140】
+
+## 7. 音频与反馈系统
+
+`SoundManager` 支持多种后端（miniaudio / irrKlang），内部维护 BGM 场景列表、当前播放状态、音量控制接口以及大量常用音效枚举。客户端场景切换或 UI 交互时调用 `PlayBGM`、`PlaySoundEffect` 等函数即可统一管理音乐与提示音。【F:gframe/sound_manager.h†L15-L106】
+
+在主循环中，`SoundManager` 会根据对战状态自动切换战斗/胜利/失败/优势劣势 BGM，菜单与牌组界面也使用专用曲目，保证玩家反馈一致性。【F:gframe/game.cpp†L1157-L1232】
+
+## 8. 扩展建议
+
+- 新增界面或按钮时，需在 `Game::Initialize()` 中创建控件、在对应事件处理器（`menuHandler` 或 `ClientField::OnEvent`）中注册逻辑，并考虑是否需要在 `SoundManager` 添加音效常量，以维持统一交互体验。【F:gframe/game.cpp†L240-L1147】【F:gframe/event_handler.cpp†L16-L198】【F:gframe/sound_manager.h†L45-L106】
+- 拓展网络协议需同步更新 `network.h` 的结构体定义，并在 `DuelClient::HandleSTOCPacketLan` / `SendPacketToServer` 侧实现序列化与 UI 反馈，确保不同模式都能正确解析新消息。【F:gframe/network.h†L16-L195】【F:gframe/duelclient.cpp†L666-L855】
+- 若添加新的单机/录像特性，可在 `SingleMode` 或 `Replay` 扩展处理逻辑，同时在 `ClientField` 的事件/渲染流程中补充对应 UI 控件与状态更新，保证多模式间状态同步。【F:gframe/single_mode.h†L10-L37】【F:gframe/replay.h†L12-L121】【F:gframe/client_field.h†L26-L164】

--- a/dev/docs/engine/ocgcore_engine_reference_zh.md
+++ b/dev/docs/engine/ocgcore_engine_reference_zh.md
@@ -1,0 +1,76 @@
+# ocgcore 引擎模块详解
+
+本文档针对 `ocgcore/` 目录下的 C++ 源码，深入拆解游戏对战内核的组成、职责分层与常见交互流程，帮助内核与脚本开发者定位扩展点、理解各模块的真实实现。
+
+## 1. 总体结构
+
+`duel` 类是整个对战内核的根对象，它持有 Lua 解释器、`field` 场地实例、梅森旋转随机数引擎与所有对象集合，并暴露读取/写入消息缓冲区的基础设施。【F:ocgcore/duel.h†L31-L73】【F:ocgcore/duel.cpp†L18-L153】
+
+核心对外接口集中在 `ocgapi.h`。宿主通过设置脚本/卡片/消息回调、调用 `create_duel_v2` 构造 `duel`，随后使用一系列 API 向内核灌入卡片、同步玩家资源并驱动 `process()` 主循环。【F:ocgcore/ocgapi.h†L39-L73】
+
+Lua 解释器负责加载脚本与执行效果逻辑，而所有战斗状态则落地在 `field`、`card`、`effect` 等 C++ 对象中，保证既能脚本扩展又具有稳定的执行效率。
+
+## 2. 对战实例（duel）
+
+- **生命周期管理**：构造函数初始化 Lua 解释器、`field`、临时卡与消息缓冲；析构与 `clear()` 会逐个销毁卡牌、群组、效果及其 Lua 引用，确保重复开局不会残留状态或内存泄漏。【F:ocgcore/duel.cpp†L18-L57】
+- **对象池与脚本注册**：`new_card/new_group/new_effect` 将实例插入 `std::unordered_set` 并调用解释器的 `register_*` 以供 Lua 获取引用；`delete_*` 则移除集合并解除 Lua 侧引用，必要时把对象从脚本临时集合 `sgroups` 与假定状态集合 `assumes` 中清除。【F:ocgcore/duel.h†L38-L65】【F:ocgcore/duel.cpp†L58-L127】
+- **消息管道**：`write_buffer*`/`read_buffer` 向宿主发送事件或查询结果；`set_response*` 把玩家输入写回 `field::returns`。`buffer_size()` 把消息长度编码进 `process()` 返回值，提醒宿主读取。【F:ocgcore/duel.h†L52-L73】【F:ocgcore/duel.cpp†L107-L153】
+- **随机性与注册表**：`get_next_integer` 抽象 RNG 版本，`registry` 提供键值存储，对应 `ocgapi` 的 registry API，可用于脚本共享状态或记录自定义战局数据。【F:ocgcore/duel.h†L32-L47】【F:ocgcore/duel.cpp†L149-L153】【F:ocgcore/ocgapi.h†L76-L83】
+
+## 3. 场地状态模型（field）
+
+`field` 拥有全部对战运行时数据：`player_info` 维护 LP、补给、卡组/墓地/额外区列表；`field_effect` 记录场地区域内生效的各种效果集合；`field_info` 跟踪回合数、阶段、全局唯一 ID 等元数据。【F:ocgcore/field.h†L81-L138】
+
+核心成员 `processor core` 维护流程队列，`return_value` 作为与宿主交互的返回缓冲；`nil_event`、`rose_card` 等字段用于脚本扩展（如玫瑰决斗）或默认事件对象。【F:ocgcore/field.h†L181-L205】【F:ocgcore/field.h†L365-L379】
+
+### 3.1 卡片入场与同步
+
+`add_card/remove_card/move_card` 等函数负责把 `card` 放入对应列表，并设置 `fieldid`、`unique_fieldid`、`turnid`、Pendulum 计数与位置标记。每次操作都会刷新玩家信息并调用 `card::apply_field_effect` 让持续效果立即生效。【F:ocgcore/field.cpp†L65-L191】
+
+`reload_field_info` 会把 LP、场区占用、连锁信息等打包到消息缓冲里，宿主可用于断线重连或状态刷新，一次性重建 UI。【F:ocgcore/field.cpp†L65-L104】
+
+### 3.2 查询与判定接口
+
+`get_useable_count*`、`get_spsummonable_count*` 等函数综合检查区域禁用、素材要求、唯一性等限制，是脚本判定召唤/移动是否合法的基础；`filter_field_effect`、`filter_player_effect` 从 `field_effect` 聚合中筛选满足条件的效果集合，为触发/适用流程提供候选。【F:ocgcore/field.h†L384-L456】【F:ocgcore/field.h†L428-L435】
+
+大量 `is_player_can_*`、`check_*` 方法把复杂规则拆成可复用的判定，例如素材收集、XYZ/Synchro 条件计算、链接区判定等，Lua 侧可以直接调用这些接口避免重复编码。【F:ocgcore/field.h†L436-L520】
+
+## 4. 流程调度（processor）
+
+`field::add_process` 将待执行的 `processor_unit` 放入 `core.subunits`，随后 `process()` 把它们拼接到 `core.units` 并按 `type` 分发：
+
+- **操作等待**：如 `PROCESSOR_SELECT_CARD`、`PROCESSOR_SELECT_CHAIN` 等在等待玩家输入时返回 `PROCESSOR_WAITING | buffer_size()`，提示宿主读取消息后写回响应。
+- **步骤推进**：`adjust_step`、`process_turn`、`refresh_location_info` 等函数按 `step` 拆分多阶段执行，完成后弹出对应 `processor_unit`。
+
+这种链表+状态机的结构支持嵌套流程（通过 `core.subunits`）并明确阻塞点，是引擎与 UI 协作的核心。【F:ocgcore/processor.cpp†L17-L200】
+
+## 5. 卡片对象模型（card）
+
+`card_state` 捕捉卡片当前与历史属性、位置、控制者、原因等信息；配套的 `query_cache` 避免重复计算查询结果，`material_info` 记录同调/超量/链接素材限制，供脚本查询。【F:ocgcore/card.h†L37-L111】
+
+`card` 本体维护先前/当前/临时状态、召唤信息、唯一性 ID、计数器映射、关联关系、装备/叠放目标等，并携带 `metadata` 以便脚本附加标签。`sendto_param`、`sum_param` 等字段用于在流程间传递临时参数（如送去何处、召唤使用的素材）。【F:ocgcore/card.h†L113-L200】
+
+## 6. 效果系统（effect 与 effectset）
+
+`effect` 记录描述文本、代码、作用范围、重置标志、计数限制与触发条件函数指针，同时缓存激活时的持有者、位置、连锁信息。`is_activateable`、`check_count_limit`、`is_chainable` 等方法综合事件上下文判断能否发动，`reset`/`recharge` 在阶段结束或效果失效时清理状态。【F:ocgcore/effect.h†L29-L130】
+
+`required_handorset_effects`、`flag` 标志数组与 `hint_timing` 支撑可选连锁、必发效果与提示时机；当效果授予其他卡时，`is_granted` 与场地中的 `grant_effect_container` 一起维护授予链路，确保效果可追踪并在移除时正确撤销。【F:ocgcore/effect.h†L45-L130】【F:ocgcore/field.h†L103-L127】
+
+## 7. Lua 解释器桥接（interpreter）
+
+解释器维护 Lua 主状态、协程表、参数队列与内存跟踪器，向脚本开放 `load_script`、`call_function`、`call_card_function`、`call_coroutine` 等接口。`add_param`/`push_param` 将 C++ 对象或整数压入 Lua 栈，`card2value`/`group2value`/`effect2value` 保证跨语言引用一致，并支持复制函数引用用于异步操作。【F:ocgcore/interpreter.h†L27-L88】
+
+`is_effect_check`、`check_filter` 等辅助函数为 Lua 回调提供快速条件判断；`clone_function_ref`、`get_ref_object` 则支撑效果克隆、延迟执行等高级脚本需求。
+
+## 8. 宿主交互与 API 流程
+
+1. **初始化**：宿主注册 `script_reader`、`card_reader`、`message_handler` 后，通过 `create_duel_v2` 构建 `duel`，再调用 `set_player_info`、`set_player_supply`、`new_card` 等 API 完成初始牌组与资源设定。【F:ocgcore/ocgapi.h†L39-L70】
+2. **主循环**：重复调用 `process()` 直到返回 `PROCESSOR_END`。当返回值含 `PROCESSOR_WAITING` 时，应读取 `get_message`/`read_buffer` 中的消息，展示给玩家，并在收到输入后调用 `set_response*` 推进流程。【F:ocgcore/ocgapi.h†L63-L73】【F:ocgcore/duel.cpp†L107-L153】【F:ocgcore/processor.cpp†L35-L200】
+3. **查询与同步**：宿主可随时使用 `query_card`、`query_field_info`、`get_registry_*` 等 API 获取最新状态或自定义存档，支撑断线重连、录像与调试工具。【F:ocgcore/ocgapi.h†L67-L83】
+4. **收尾**：对战结束后调用 `end_duel` 释放场地与脚本资源，必要时执行 `duel::clear()` 或直接销毁实例，防止宿主残留旧数据。【F:ocgcore/ocgapi.h†L54-L55】【F:ocgcore/duel.cpp†L29-L57】
+
+## 9. 扩展建议
+
+- 新增事件或阶段时，需要在 `processor::process()` 的 `switch` 中添加 `PROCESSOR_*` 分支，并实现对应的处理函数/消息封装，确保等待玩家输入时返回 `PROCESSOR_WAITING`。【F:ocgcore/processor.cpp†L35-L200】
+- 扩展卡片属性需同步更新 `card_state`、`query_cache` 与 Lua 查询接口，同时在 `reload_field_info` 中补充字段，保持脚本与宿主看到的一致数据。【F:ocgcore/card.h†L37-L111】【F:ocgcore/field.cpp†L65-L104】
+- 面向宿主的新 API 应同步声明于 `ocgapi.h` 并在实现中写入消息缓冲或修改场地，必要时在 `interpreter` 层提供脚本封装，使 C++/Lua/宿主三方保持一致语义。【F:ocgcore/ocgapi.h†L39-L83】【F:ocgcore/interpreter.h†L27-L88】


### PR DESCRIPTION
## Summary
- deepen the ocgcore engine reference with lifecycle, processor flow, object model, and host API guidance in Chinese
- broaden the gframe client reference with lifecycle, resource management, network stack, UI input flow, and audio/mode notes in Chinese

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68f44d0d18ec83298c06c1eda99630ea